### PR TITLE
Moved the gsl package from Imports to Suggests...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Date: 2020-08-04
 Authors@R: c(person("Ken", "Kelley", role=c("aut", "cre"), email="kkelley@nd.edu"))
 Maintainer: Ken Kelley <kkelley@nd.edu>
 Depends: R (>= 3.5.0), stats
-Imports: boot, gsl, lavaan, MASS, methods, mnormt, nlme, OpenMx, parallel, sem, semTools 
+Imports: boot, lavaan, MASS, methods, mnormt, nlme, OpenMx, parallel, sem, semTools
+Suggests: gsl
 Description: Implements methods that useful in designing research studies and analyzing data, with 
 	particular emphasis on methods that are developed for or used within the behavioral, 
 	educational, and social sciences (broadly defined). That being said, many of the methods 


### PR DESCRIPTION
... in DESCRIPTION file.

Hi @yelleKneK,

I already wrote to you via email, but then found out that MBESS is now on github. This is a tiny change that will greatly benefit R package developers that rely on MBESS in their own packages. Recently, the **gsl** package has become a hard-to-fulfill dependency, because it now relies on version 2.5 of the GSL library, which is not available for Ubuntu versions prior to 20.04 LTS (see this issue RobinHankin/gsl#17). Consequently, continuous-integration services that run on such systems fail because the **gsl** package cannot be installed. I read your code and found that even though the **gsl** package is defined as a "hard" dependency in the `DESCRIPTION` file, the code itself does not "hardly" depend on it, because you check for a working installation of **gsl** via `requireNamespace("gsl")`. 

It would be great for our workflows if you accepted this PR. If there is anything I missed that might require some extra work, I am more than willing to put some effort into this.

Best regards,
Marius