### PR TITLE
Fixes #4

### DIFF
--- a/R/Sigma.2.SigmaStar.R
+++ b/R/Sigma.2.SigmaStar.R
@@ -82,7 +82,7 @@ for (i in 1:q){
 	B[,i]<- (-1)*D%*%vech(W.inv%*%Sigma.deriv[,,i]%*%W.inv) 
 	}
 
-y <- matrix(1:p.star/100, p.star,1)
+y <- matrix(rnorm(p.star), p.star,1)
 B.qr<- qr(B)
 e.tilt <- qr.resid(B.qr, y)
 


### PR DESCRIPTION
Redefine y as a random vector instead of a fixed vector so that calls to Sigma.2.SigmaStar() give different results unless the same seed is used.